### PR TITLE
Fix/add missing ethsecp256k1 pubkey usages

### DIFF
--- a/packages/amino/src/encoding.ts
+++ b/packages/amino/src/encoding.ts
@@ -6,6 +6,7 @@ import {
   Ed25519Pubkey,
   EthSecp256k1Pubkey,
   isEd25519Pubkey,
+  isEthSecp256k1Pubkey,
   isMultisigThresholdPubkey,
   isSecp256k1Pubkey,
   MultisigThresholdPubkey,
@@ -60,6 +61,7 @@ export function encodeEthSecp256k1Pubkey(pubkey: Uint8Array): EthSecp256k1Pubkey
 // Prefixes listed here: https://github.com/tendermint/tendermint/blob/d419fffe18531317c28c29a292ad7d253f6cafdf/docs/spec/blockchain/encoding.md#public-key-cryptography
 // Last bytes is varint-encoded length prefix
 const pubkeyAminoPrefixSecp256k1 = fromHex("eb5ae987" + "21" /* fixed length */);
+const pubkeyAminoPrefixEthSecp256k1 = fromHex("5D7423DF" + "21" /* fixed length */);
 const pubkeyAminoPrefixEd25519 = fromHex("1624de64" + "20" /* fixed length */);
 const pubkeyAminoPrefixSr25519 = fromHex("0dfb1005" + "20" /* fixed length */);
 /** See https://github.com/tendermint/tendermint/commit/38b401657e4ad7a7eeb3c30a3cbf512037df3740 */
@@ -222,6 +224,8 @@ export function encodeAminoPubkey(pubkey: Pubkey): Uint8Array {
     return new Uint8Array([...pubkeyAminoPrefixEd25519, ...fromBase64(pubkey.value)]);
   } else if (isSecp256k1Pubkey(pubkey)) {
     return new Uint8Array([...pubkeyAminoPrefixSecp256k1, ...fromBase64(pubkey.value)]);
+  } else if (isEthSecp256k1Pubkey(pubkey)) {
+    return new Uint8Array([...pubkeyAminoPrefixEthSecp256k1, ...fromBase64(pubkey.value)])
   } else {
     throw new Error("Unsupported pubkey type");
   }

--- a/packages/amino/src/pubkeys.ts
+++ b/packages/amino/src/pubkeys.ts
@@ -64,7 +64,7 @@ export interface SinglePubkey extends Pubkey {
 }
 
 export function isSinglePubkey(pubkey: Pubkey): pubkey is SinglePubkey {
-  const singPubkeyTypes: string[] = [pubkeyType.ed25519, pubkeyType.secp256k1, pubkeyType.sr25519];
+  const singPubkeyTypes: string[] = [pubkeyType.ed25519, pubkeyType.secp256k1, pubkeyType.ethsecp256k1, pubkeyType.sr25519];
   return singPubkeyTypes.includes(pubkey.type);
 }
 

--- a/packages/amino/src/signerutils.ts
+++ b/packages/amino/src/signerutils.ts
@@ -4,10 +4,11 @@
 
 import type { AccountData } from "./signer";
 import { encodeEthSecp256k1Pubkey, encodeSecp256k1Pubkey } from "./encoding";
+import { EthSecp256k1Pubkey, Secp256k1Pubkey } from "./pubkeys";
 
 /**
  * Checks if an account uses Ethereum secp256k1 keys by examining the algorithm name.
- * 
+ *
  * Handle Ethereum secp256k1 keys with dual naming convention support:
  * Different wallets and chains report Ethereum key algorithms inconsistently:
  * - "eth_secp256k1" (with underscore) - de facto standard used by Keplr wallet, CosmJS, some Cosmos SDK chains
@@ -23,14 +24,14 @@ export function isEthereumSecp256k1Account(account: AccountData): boolean {
 
 /**
  * Gets the correctly encoded amino pubkey for an account based on its algorithm.
- * 
+ *
  * This utility automatically selects the appropriate encoding function based on whether
  * the account uses Ethereum secp256k1 keys or standard secp256k1 keys.
  *
  * @param account The account data from a signer
  * @returns The amino-encoded pubkey (EthSecp256k1Pubkey or Secp256k1Pubkey)
  */
-export function getAminoPubkey(account: AccountData): any {
+export function getAminoPubkey(account: AccountData): EthSecp256k1Pubkey | Secp256k1Pubkey {
   if (isEthereumSecp256k1Account(account)) {
     return encodeEthSecp256k1Pubkey(account.pubkey);
   } else {


### PR DESCRIPTION
## Prove `pubkeyAminoPrefixEthSecp256k1` is correct
### 1. Reproduce the existing prefix to prove my method is correct
According to the [Amino document](https://github.com/tendermint/go-amino?tab=readme-ov-file#computing-the-prefix-and-disambiguation-bytes), I compute the below result, which matches the existing `pubkeyAminoPrefixSecp256k1`.
<img width="2806" height="992" alt="image" src="https://github.com/user-attachments/assets/274a6599-e61f-4af1-a32f-8825e63a8d21" />

### 2. Use the same method to compute `pubkeyAminoPrefixEthSecp256k1`
<img width="1756" height="448" alt="image" src="https://github.com/user-attachments/assets/1bc705a0-89ce-401b-a6cd-0707a0cb1b1e" />

